### PR TITLE
Add two properties: selection.mimetype and selection.description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /install
 /third_parties
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,9 @@ set(SHELLANYTHING_INSTALL_INCLUDE_DIR  "include/shellanything-${SHELLANYTHING_VE
 set(SHELLANYTHING_INSTALL_CMAKE_DIR    ${SHELLANYTHING_INSTALL_LIB_DIR}) # CMake files (*.cmake) should have the same destination as the library files. Some also prefers to use "cmake".
 set(SHELLANYTHING_INSTALL_DOC_DIR      "docs")
 
+# magic.mgc file
+set(LIBMAGIC_MGC_DIR "${CMAKE_SOURCE_DIR}/third_parties/libmagic/install/binary")
+
 ##############################################################################################################################################
 # Project settings
 ##############################################################################################################################################
@@ -289,6 +292,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/shellanything-config.cmake DESTI
 
 install(FILES ${CMAKE_SOURCE_DIR}/resources/register.bat
               ${CMAKE_SOURCE_DIR}/resources/unregister.bat
+              ${LIBMAGIC_MGC_DIR}/magic.mgc
               DESTINATION ${SHELLANYTHING_INSTALL_BIN_DIR})
 
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/shellanything DESTINATION ${SHELLANYTHING_INSTALL_INCLUDE_DIR})

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -66,6 +66,7 @@ before_build:
 - cmd: call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_rapidassist.bat
 - cmd: call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_glog.bat
 - cmd: call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_grip.bat
+- cmd: call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_libmagic.bat
 
 build_script:
 - cmd: call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\build_library.bat

--- a/ci/appveyor/build_library.bat
+++ b/ci/appveyor/build_library.bat
@@ -10,6 +10,7 @@ set GTEST_ROOT=%APPVEYOR_BUILD_FOLDER%\third_parties\googletest\install
 set rapidassist_DIR=%APPVEYOR_BUILD_FOLDER%\third_parties\RapidAssist\install
 set tinyxml2_DIR=%APPVEYOR_BUILD_FOLDER%\third_parties\tinyxml2\install
 set glog_DIR=%APPVEYOR_BUILD_FOLDER%\third_parties\glog\install_dir
+set libmagic_DIR=%APPVEYOR_BUILD_FOLDER%\third_parties\libmagic\install
 set INSTALL_LOCATION=%APPVEYOR_BUILD_FOLDER%\install
 
 echo ============================================================================
@@ -18,6 +19,7 @@ echo ===========================================================================
 cd /d %APPVEYOR_BUILD_FOLDER%
 mkdir build >NUL 2>NUL
 cd build
+echo %libmagic_DIR%
 cmake -Wno-dev -DCMAKE_GENERATOR_PLATFORM=%Platform% -T %PlatformToolset% -DCMAKE_INSTALL_PREFIX=%INSTALL_LOCATION% -DSHELLANYTHING_BUILD_TEST=ON -DBUILD_SHARED_LIBS=OFF ..
 if %errorlevel% neq 0 exit /b %errorlevel%
 
@@ -47,6 +49,7 @@ set GTEST_ROOT=
 set rapidassist_DIR=
 set tinyxml2_DIR=
 set glog_DIR=
+set LIBMAGIC_DIR=
 set INSTALL_LOCATION=
 
 ::Return to launch folder

--- a/ci/appveyor/install_libmagic.bat
+++ b/ci/appveyor/install_libmagic.bat
@@ -1,0 +1,63 @@
+@echo off
+
+:: Validate appveyor's environment
+if "%APPVEYOR_BUILD_FOLDER%"=="" (
+  echo Please define 'APPVEYOR_BUILD_FOLDER' environment variable.
+  exit /B 1
+)
+
+set LIBMAGIC_ROOT=%APPVEYOR_BUILD_FOLDER%\third_parties\libmagic
+set LIBMAGIC_DIR=%LIBMAGIC_ROOT%\install
+
+set PCRE2_ROOT=%LIBMAGIC_ROOT%\pcre2
+set PCRE2_INSTALL_DIR=%PCRE2_ROOT%\install_dir
+
+echo ============================================================================
+echo Cloning libmagic into %APPVEYOR_BUILD_FOLDER%\third_parties\libmagic
+echo ============================================================================
+mkdir %APPVEYOR_BUILD_FOLDER%\third_parties >NUL 2>NUL
+cd %APPVEYOR_BUILD_FOLDER%\third_parties
+@REM git clone --recurse-submodules "https://github.com/julian-r/file-windows" libmagic
+git clone --recurse-submodules "https://github.com/Cirn09/file-windows" libmagic
+
+cd libmagic
+echo.
+
+@REM echo Checking out version 5.38...
+@REM git -c advice.detachedHead=false checkout v5.38
+@REM echo.
+
+echo ============================================================================
+echo Preparing...
+echo ============================================================================
+cd /d %PCRE2_ROOT%
+mkdir build >NUL 2>NUL
+cd build
+cmake -Wno-dev -DCMAKE_GENERATOR_PLATFORM=%Platform% -T %PlatformToolset% -DCMAKE_INSTALL_PREFIX="%PCRE2_INSTALL_DIR%" ..
+if %errorlevel% neq 0 exit /b %errorlevel%
+cmake --build . --config %Configuration%
+if %errorlevel% neq 0 exit /b %errorlevel%
+cmake --install . --config %CONFIGURATION%
+if %errorlevel% neq 0 exit /b %errorlevel%
+echo.
+
+echo ============================================================================
+echo Compiling...
+echo ============================================================================
+
+cd /d %LIBMAGIC_ROOT%
+mkdir build >NUL 2>NUL
+cd build
+cmake -Wno-dev -DCMAKE_GENERATOR_PLATFORM=%Platform% -T %PlatformToolset% -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=%CONFIGURATION% -DCMAKE_INSTALL_PREFIX="%libmagic_DIR%" ..
+@REM cmake -G "%GENERATOR%" -DCMAKE_BUILD_TYPE=%CONFIGURATION% ..
+if %errorlevel% neq 0 exit /b %errorlevel%
+cmake --build . --config %Configuration%
+if %errorlevel% neq 0 exit /b %errorlevel%
+echo.
+
+echo ============================================================================
+echo Installing into %libmagic_DIR%
+echo ============================================================================
+cmake --build . --config %Configuration% --target INSTALL
+if %errorlevel% neq 0 exit /b %errorlevel%
+echo.

--- a/ci/local/build_with_defaults.bat
+++ b/ci/local/build_with_defaults.bat
@@ -26,6 +26,8 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_glog.bat
 if %errorlevel% neq 0 exit /b %errorlevel%
 call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_grip.bat
+if %errorlevel% neq 0 exit /b %errorlevel%
+call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\install_libmagic.bat
 
 call %APPVEYOR_BUILD_FOLDER%\ci\appveyor\build_library.bat
 if %errorlevel% neq 0 exit /b %errorlevel%

--- a/include/shellanything/Context.h
+++ b/include/shellanything/Context.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <vector>
+#include "FileMagic.h"
 
 namespace shellanything
 {
@@ -92,6 +93,7 @@ namespace shellanything
     ElementList mElements;
     int mNumFiles;
     int mNumDirectories;
+    FileMagic fm;
 
   };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(rapidassist REQUIRED)
 find_package(tinyxml2 REQUIRED)
 find_package(glog REQUIRED)
+find_package(libmagic REQUIRED)
 
 #resource.rc
 set(SHELLANYTHING_RESOURCE_RC ${CMAKE_BINARY_DIR}/src/resource.rc)
@@ -60,6 +61,8 @@ add_library(shellanything STATIC
   ConfigManager.cpp
   Context.cpp
   DefaultSettings.cpp
+  FileMagic.h
+  FileMagic.cpp
   Icon.cpp
   InputBox.h
   InputBox.cpp
@@ -131,6 +134,10 @@ add_custom_command( TARGET shellanything POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
                     ${CMAKE_SOURCE_DIR}/resources/refresh.bat $<TARGET_FILE_DIR:shellanything>/refresh.bat
                     COMMENT "Copying refresh.bat script.")
+add_custom_command( TARGET shellanything POST_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                    ${LIBMAGIC_MGC_DIR}/magic.mgc $<TARGET_FILE_DIR:shellanything>/magic.mgc
+                    COMMENT "Copying magic.mgc.")
 
 # Force CMAKE_DEBUG_POSTFIX for executables
 set_target_properties(shellanything   PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
@@ -149,6 +156,7 @@ target_include_directories(shellanything
     rapidassist
     glog::glog
     libeval
+    libmagic
 )
 target_include_directories(shellext
   PUBLIC
@@ -156,6 +164,7 @@ target_include_directories(shellext
   PRIVATE
     rapidassist
     glog::glog
+    libmagic
 )
 target_include_directories(libeval
   PUBLIC
@@ -163,8 +172,8 @@ target_include_directories(libeval
   PRIVATE
     ${PACKAGE_DOWNLOAD_DIR}/exprtk-master
 )
-target_link_libraries(shellanything   PRIVATE ${PTHREAD_LIBRARIES} ${GTEST_LIBRARIES} rapidassist glog::glog libeval)
-target_link_libraries(shellext        PRIVATE shellanything rapidassist glog::glog)
+target_link_libraries(shellanything   PRIVATE ${PTHREAD_LIBRARIES} ${GTEST_LIBRARIES} rapidassist glog::glog libeval libmagic)
+target_link_libraries(shellext        PRIVATE shellanything rapidassist glog::glog libmagic)
 
 # Also add Tinyxml2 include and libraries.
 # The include/libraries are added at the end to allow supporting both static or shared libraries (the target names are different).

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -37,7 +37,8 @@ namespace shellanything
 
   Context::Context() :
     mNumFiles(0),
-    mNumDirectories(0)
+    mNumDirectories(0),
+    fm()
   {
   }
 
@@ -82,6 +83,10 @@ namespace shellanything
     std::string selection_count          ;
     std::string selection_files_count    ;
     std::string selection_directories_count;
+    std::string selection_mimetype       ;
+    std::string selection_description    ;
+    // std::string selection_extension      ;
+    // std::string selection_charset        ;
 
     // Get the separator string for multiple selection 
     const std::string & selection_multi_separator = pmgr.GetProperty(Context::MULTI_SELECTION_SEPARATOR_PROPERTY_NAME);
@@ -112,6 +117,10 @@ namespace shellanything
       std::string element_selection_filename_ext    = ra::filesystem::GetFileExtention(element_selection_filename);
       std::string element_selection_drive_letter    = GetDriveLetter(element);
       std::string element_selection_drive_path      = GetDrivePath(element);
+      std::string element_selection_mimetype        = fm.GetMIMEType(element_selection_path);
+      std::string element_selection_description     = fm.GetDescription(element_selection_path);
+      // std::string element_selection_extension       = fm.GetExtension(element_selection_path);
+      // std::string element_selection_charset         = fm.GetCharset(element_selection_path);
  
       // Add a separator between values
       if (!selection_path           .empty()) selection_path            .append( selection_multi_separator );
@@ -123,6 +132,10 @@ namespace shellanything
       if (!selection_filename_ext   .empty()) selection_filename_ext    .append( selection_multi_separator );
       if (!selection_drive_letter   .empty()) selection_drive_letter    .append( selection_multi_separator );
       if (!selection_drive_path     .empty()) selection_drive_path      .append( selection_multi_separator );
+      if (!selection_mimetype       .empty()) selection_mimetype        .append( selection_multi_separator );
+      if (!selection_description    .empty()) selection_description     .append( selection_multi_separator );
+      // if (!selection_extension      .empty()) selection_extension       .append( selection_multi_separator );
+      // if (!selection_charset        .empty()) selection_charset         .append( selection_multi_separator );
 
       // Append this specific element properties to the global property string
       selection_path           .append( element_selection_path            );
@@ -134,6 +147,10 @@ namespace shellanything
       selection_filename_ext   .append( element_selection_filename_ext    );
       selection_drive_letter   .append( element_selection_drive_letter    );
       selection_drive_path     .append( element_selection_drive_path      );
+      selection_mimetype       .append( element_selection_mimetype        );
+      selection_description    .append( element_selection_description     );
+      // selection_extension      .append( element_selection_extension       );
+      // selection_charset        .append( element_selection_charset         );
     }
  
     pmgr.SetProperty("selection.path"               , selection_path           );
@@ -145,6 +162,11 @@ namespace shellanything
     pmgr.SetProperty("selection.filename.extension" , selection_filename_ext   );
     pmgr.SetProperty("selection.drive.letter"       , selection_drive_letter   );
     pmgr.SetProperty("selection.drive.path"         , selection_drive_path     );
+    pmgr.SetProperty("selection.drive.path"         , selection_drive_path     );
+    pmgr.SetProperty("selection.mimetype"           , selection_mimetype       );
+    pmgr.SetProperty("selection.description"        , selection_description    );
+    // pmgr.SetProperty("selection.extension"          , selection_extension      );
+    // pmgr.SetProperty("selection.charset"            , selection_charset        );
 
     selection_count             = ra::strings::ToString(elements.size());
     selection_files_count       = ra::strings::ToString(this->GetNumFiles());
@@ -167,6 +189,10 @@ namespace shellanything
     pmgr.ClearProperty("selection.filename.extension" );
     pmgr.ClearProperty("selection.drive.letter"       );
     pmgr.ClearProperty("selection.drive.path"         );
+    pmgr.ClearProperty("selection.mimetype"           );
+    pmgr.ClearProperty("selection.description"        );
+    // pmgr.ClearProperty("selection.extension"          );
+    // pmgr.ClearProperty("selection.charset"            );
   }
  
   const Context::ElementList & Context::GetElements() const

--- a/src/FileMagic.cpp
+++ b/src/FileMagic.cpp
@@ -1,0 +1,156 @@
+/**********************************************************************************
+ * MIT License
+ * 
+ * Copyright (c) 2018 Antoine Beauchamp
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *********************************************************************************/
+
+#include <windows.h>
+
+#include "rapidassist/filesystem_utf8.h"
+#include "rapidassist/unicode.h"
+#include "rapidassist/errors.h"
+
+#include "FileMagic.h"
+#include "ErrorManager.h"
+
+
+std::string GetMGCPath()
+{
+  std::string path;
+  wchar_t buffer[MAX_PATH] = {0};
+  HMODULE hModule = NULL;
+  if (!GetModuleHandleExW( GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                          GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                          (LPCWSTR) __FUNCTIONW__,
+                          &hModule))
+  {
+    uint32_t error_code = ra::errors::GetLastErrorCode();
+    std::string desc = ra::errors::GetErrorCodeDescription(error_code);
+    std::string message = std::string() +
+      "Error in function '" + __FUNCTION__ + "()', file '" + __FILE__ + "', line " + ra::strings::ToString(__LINE__) + ".\n" +
+      "\n" +
+      "Failed getting the file path of the current module.\n" +
+      "The following error code was returned:\n" +
+      "\n" +
+      ra::strings::Format("0x%08x", error_code) + ": " + desc;
+
+    //display an error on 
+    shellanything::ShowErrorMessage("ShellAnything Error", message);
+
+    return std::string();
+  }
+
+  /*get the path of this DLL*/
+  GetModuleFileNameW(hModule, buffer, sizeof(buffer));
+  if (buffer[0] != '\0')
+  {
+    path = ra::unicode::UnicodeToUtf8(buffer);
+  }
+  
+  std::string mgc_path = ra::filesystem::GetParentPath(path) + "\\magic.mgc";
+  return mgc_path;
+}
+
+namespace shellanything
+{
+  FileMagic::FileMagic()
+  {
+    magic_cookie = magic_open(MAGIC_NONE);
+    std::string path = GetMGCPath();
+
+    if (magic_cookie == NULL) {
+        ShowErrorMessage("ShellAnything(libmagic) Error", "ERROR opening MAGIC_MIME_TYPE: out of memory\n");
+        return;
+    }
+    if (magic_load(magic_cookie, path.c_str()) == -1) {
+      magic_cookie = NULL;
+      ShowErrorMessage("ShellAnything(libmagic) Error", std::string("ERROR loading with NULL file: ") + magic_error(magic_cookie));
+        return;
+    }
+  }
+
+  FileMagic::~FileMagic()
+  {
+    magic_close(magic_cookie);
+    magic_cookie = NULL;
+  }
+  
+  std::string FileMagic::GetMIMEType(const std::string & path) const
+  {
+    magic_setflags(magic_cookie, MAGIC_MIME_TYPE);
+    const char *result = magic_file(magic_cookie, path.c_str());
+    if (result == NULL)
+    {
+      ShowErrorMessage("ShellAnything(libmagic) Error", std::string("ERROR loading file: ") + magic_error(magic_cookie));
+      return std::string();
+    }
+    else
+    {
+      return std::string(result);
+    }
+  }
+
+  std::string FileMagic::GetDescription(const std::string & path) const
+  {
+    magic_setflags(magic_cookie, MAGIC_NONE);
+    const char *result = magic_file(magic_cookie, path.c_str());
+    if (result == NULL)
+    {
+      ShowErrorMessage("ShellAnything(libmagic) Error", std::string("ERROR loading file: ") + magic_error(magic_cookie));
+      return std::string();
+    }
+    else
+    {
+      return std::string(result);
+    }
+  }
+
+  std::string FileMagic::GetExtension(const std::string & path) const
+  {
+    magic_setflags(magic_cookie, MAGIC_EXTENSION);
+    const char *result = magic_file(magic_cookie, path.c_str());
+    if (result == NULL)
+    {
+      ShowErrorMessage("ShellAnything(libmagic) Error", std::string("ERROR loading file: ") + magic_error(magic_cookie));
+      return std::string();
+    }
+    else
+    {
+      return std::string(result);
+    }
+  }
+
+  std::string FileMagic::GetCharset(const std::string & path) const
+  {
+    magic_setflags(magic_cookie, MAGIC_MIME_ENCODING);
+    const char *result = magic_file(magic_cookie, path.c_str());
+    if (result == NULL)
+    {
+      ShowErrorMessage("ShellAnything(libmagic) Error", std::string("ERROR loading file: ") + magic_error(magic_cookie));
+      return std::string();
+    }
+    else
+    {
+      return std::string(result);
+    }
+  }
+
+} //shellanything

--- a/src/FileMagic.h
+++ b/src/FileMagic.h
@@ -1,0 +1,51 @@
+/**********************************************************************************
+ * MIT License
+ * 
+ * Copyright (c) 2018 Antoine Beauchamp
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *********************************************************************************/
+
+#ifndef SA_MIMETYPE_H
+#define SA_MIMETYPE_H
+
+#include <string>
+#include "magic.h"
+
+namespace shellanything
+{
+  class FileMagic
+  {
+  public:
+    FileMagic();
+    ~FileMagic();
+
+    std::string GetMIMEType(const std::string & path) const;
+    std::string GetDescription(const std::string & path) const;
+    std::string GetExtension(const std::string & path) const;
+    std::string GetCharset(const std::string & path) const;
+
+  private:
+    magic_t magic_cookie;
+  };
+
+
+} //namespace shellanything
+
+#endif //SA_MIMETYPE_H

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(GTest REQUIRED)
 find_package(rapidassist REQUIRED)
 find_package(glog REQUIRED)
+find_package(libmagic REQUIRED)
 
 set(CONFIGURATION_TEST_FILES ""
   ${CMAKE_CURRENT_SOURCE_DIR}/test_files/samples.xml
@@ -115,9 +116,9 @@ endif()
 # Force CMAKE_DEBUG_POSTFIX for executables
 set_target_properties(shellanything_unittest PROPERTIES DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
-target_include_directories(shellanything_unittest PRIVATE ${GTEST_INCLUDE_DIR} rapidassist glog::glog ${CMAKE_SOURCE_DIR}/src)
-add_dependencies(shellanything_unittest shellanything shellext)
-target_link_libraries(shellanything_unittest PUBLIC shellanything shellext PRIVATE ${PTHREAD_LIBRARIES} ${GTEST_LIBRARIES} rapidassist glog::glog)
+target_include_directories(shellanything_unittest PRIVATE ${GTEST_INCLUDE_DIR} rapidassist glog::glog libmagic ${CMAKE_SOURCE_DIR}/src)
+add_dependencies(shellanything_unittest shellanything shellext libmagic)
+target_link_libraries(shellanything_unittest PUBLIC shellanything shellext PRIVATE ${PTHREAD_LIBRARIES} ${GTEST_LIBRARIES} rapidassist glog::glog libmagic)
 
 # Copy test configuration files database to target dir
 add_custom_command( TARGET shellanything_unittest POST_BUILD


### PR DESCRIPTION
#92 
```XML
  <menu name="MIMEType:: [${selection.mimetype}]">
  </menu>
  <menu name="Description:: [${selection.description}]">
  </menu>
  <menu name="[Im DLL!]" >
      <visibility exprtk="'DLL' in '${selection.description}'"/>
  </menu>
```
![image](https://user-images.githubusercontent.com/25722111/133777661-afdfa095-4bca-4646-a902-a2cd787c165a.png)


TODO:
- [ ] Remove `GetMGCPath()`:
    `GetMGCPath()` is basically copied from `shellext.cpp`, because I don’t know how to directly link to `GetCurrentModulePathUtf8`.
- [ ] Comments and documentation:
    Writing English documents is a difficult task for me.
- [ ] `Validator::ValidateMIMEType`:
    `Libmagic` can recognize a lot of file types, but many file types do not have a special `MIMEType`. So as a supplement, I also added `selection.description`, but `selection.description` does not seem to be suitable write as a `Validator`.
- [ ] Test cases:
    I haven't figured out how to write test cases yet
- [ ] bug fix: path with Chinese character