### PR TITLE
Update ExprTk to 0.0.3 on release branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,9 @@ endif()
 # At the time of this writing, HEAD revision is commit d312ba91419c9cb12c8279fd3a19096d39dfcb5e 
 # available at https://github.com/ArashPartow/exprtk/archive/d312ba91419c9cb12c8279fd3a19096d39dfcb5e.zip
 # Using latest revision to get all bug fixes.
-set(EXPRTK_PACKAGE_URL "https://github.com/ArashPartow/exprtk/archive/master.zip")
-set(EXPRTK_PACKAGE_PATH ${PACKAGE_DOWNLOAD_DIR}/exprtk.zip)
+set(EXPRTK_TAG "0.0.3")
+set(EXPRTK_PACKAGE_URL "https://github.com/ArashPartow/exprtk/archive/refs/tags/${EXPRTK_TAG}.zip")
+set(EXPRTK_PACKAGE_PATH ${PACKAGE_DOWNLOAD_DIR}/exprtk-${EXPRTK_TAG}.zip)
 if(NOT EXISTS ${EXPRTK_PACKAGE_PATH})
   message(STATUS "Downloading exprtk package from ${EXPRTK_PACKAGE_URL}")
   file(DOWNLOAD ${EXPRTK_PACKAGE_URL} ${EXPRTK_PACKAGE_PATH}
@@ -37,7 +38,7 @@ if(NOT EXISTS ${EXPRTK_PACKAGE_PATH})
     WORKING_DIRECTORY ${PACKAGE_DOWNLOAD_DIR}
   )
 endif()
-set(EXPRTK_HEADER_PATH ${PACKAGE_DOWNLOAD_DIR}/exprtk-master/exprtk.hpp)
+set(EXPRTK_HEADER_PATH ${PACKAGE_DOWNLOAD_DIR}/exprtk-${EXPRTK_TAG}/exprtk.hpp)
 if(EXISTS ${EXPRTK_HEADER_PATH})
   message(STATUS "Found exprtk header file: ${EXPRTK_HEADER_PATH}")
 else()

--- a/src/libexprtk/CMakeLists.txt
+++ b/src/libexprtk/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories(libexprtk
   PUBLIC
     $<INSTALL_INTERFACE:${SHELLANYTHING_INSTALL_INCLUDE_DIR}>  # for clients using the installed library.
   PRIVATE
-    ${PACKAGE_DOWNLOAD_DIR}/exprtk-master
+    ${PACKAGE_DOWNLOAD_DIR}/exprtk-${EXPRTK_TAG}
 )
 
 # Define files that will be part of the installation package.


### PR DESCRIPTION
Change to point to the release branch which will always be stable and verified/tested.